### PR TITLE
Fix comprehensive NEAT learning issues preventing slimevolleyball training

### DIFF
--- a/evojax/sim_mgr.py
+++ b/evojax/sim_mgr.py
@@ -381,7 +381,9 @@ class SimManager(object):
         task_state = task_reset_func(reset_keys)
         policy_state = policy_reset_func(task_state)
         if self._num_device > 1:
-            params = split_params_for_pmap(params)
+            nodes = split_params_for_pmap(nodes)
+            weights = split_params_for_pmap(weights)
+            activations = split_params_for_pmap(activations)
             task_state = split_states_for_pmap(task_state)
             policy_state = split_states_for_pmap(policy_state)
 

--- a/evojax/trainer.py
+++ b/evojax/trainer.py
@@ -176,7 +176,7 @@ class Trainer(object):
                 start_time = time.perf_counter()
                 if isinstance(self.solver, QualityDiversityMethod):
                     self.solver.observe_bd(bds)
-                self.solver.tell(reward=scores)
+                self.solver.tell(fitness=scores)
                 self._logger.debug('solver.tell time: {0:.4f}s'.format(
                     time.perf_counter() - start_time))
 
@@ -191,7 +191,7 @@ class Trainer(object):
 
                 if i > 0 and i % self._test_interval == 0:
                     bestWeights, bestActivations = self.solver.best_params
-                    bestnodes = len(bestWeights) #num nodes
+                    bestnodes = bestWeights.shape[0]  # Use matrix dimension instead of len()
                     test_scores, _ = self.sim_mgr.eval_params(
                             nodes=bestnodes, weights = bestWeights, activations = bestActivations, test=True)
                     #best_params = self.solver.best_params
@@ -216,7 +216,7 @@ class Trainer(object):
 
             # Test and save the final model.
             bestWeights, bestActivations = self.solver.best_params
-            bestnodes = len(bestWeights)
+            bestnodes = bestWeights.shape[0]
             test_scores, _ = self.sim_mgr.eval_params(
                 nodes=bestnodes, weights=bestWeights, activations=bestActivations, test=True)
             self._logger.info(

--- a/examples/train_slimevolley.py
+++ b/examples/train_slimevolley.py
@@ -65,7 +65,7 @@ def parse_args():
     parser.add_argument(
         '--n-repeats', type=int, default=2, help='Training repetitions.') #default 16 dont work, need sq matrix
     parser.add_argument(
-        '--max-iter', type=int, default=20, help='Max training iterations.')
+        '--max-iter', type=int, default=200, help='Max training iterations.')
     parser.add_argument(
         '--test-interval', type=int, default=50, help='Test interval.')
     parser.add_argument(

--- a/myneat/__init__.py
+++ b/myneat/__init__.py
@@ -1,2 +1,2 @@
-# from .ann import *
-# from .neat import *
+from .ann import *
+from .neat import *

--- a/myneat/ann.py
+++ b/myneat/ann.py
@@ -197,10 +197,14 @@ def act(nodes, weights, aVec, inPattern): #feedfwd part, used jax.jit bc lots of
   """
   total_nodes = weights.shape[0]
 
+  n_inputs = len(inPattern)
+  n_bias = 1
+  total_inputs = n_inputs + n_bias
+
   @jax.jit
   def initialize_nodeAct(inPattern):
       return jnp.concatenate(
-          [jnp.array([1.0]), inPattern, jnp.zeros(total_nodes - 13)]
+          [jnp.array([1.0]), inPattern, jnp.zeros(total_nodes - total_inputs)]
       )
 
   @jax.jit
@@ -209,9 +213,11 @@ def act(nodes, weights, aVec, inPattern): #feedfwd part, used jax.jit bc lots of
       return nodeAct.at[i].set(applyAct(aVec[i], rawAct))
 
   nodeAct = initialize_nodeAct(inPattern)
-  nodeAct = jax.lax.fori_loop(13, total_nodes, loop_body, nodeAct)
+  start_idx = total_inputs
+  nodeAct = jax.lax.fori_loop(start_idx, total_nodes, loop_body, nodeAct)
 
-  return jax.lax.dynamic_slice(nodeAct, (nodes - 3,), (3,))
+  n_outputs = 3
+  return nodeAct[-n_outputs:]
   # Turn weight vector into weight matrix
   # if np.ndim(weights) < 2:
   #     nNodes = int(np.sqrt(np.shape(weights)[0]))
@@ -268,8 +274,10 @@ def applyAct(actId, x):
   """
   # print(actId , "hellloo") # Traced<ShapedArray(float32[16])>with<DynamicJaxprTrace(level=6/0)>  ? 
   
+  actId = jnp.clip(actId.astype(int), 0, 10)
+  
   return jax.lax.switch(
-      actId.astype(int),  # The key to select which function to apply
+      actId,
       [
           lambda: x,  # Linear
           lambda: jnp.where(x > 0, 1.0, 0.0),  # Unsigned Step Function

--- a/myneat/neat.py
+++ b/myneat/neat.py
@@ -49,8 +49,11 @@ class NeatAlgo(NEAlgorithm): #need ask,tell, best params, state stuff is optiona
     self.best_weights = None
     self.best_activations = None
     self.best_idx = None
-    self.pop_size = self.p['popSize'] #used to be initialized to 0, did not work
+    # self.pop_size = self.p['popSize'] #used to be initialized to 0, did not work
 
+  @property
+  def pop_size(self):
+      return len(self.pop) if self.pop else self.p['popSize']
 
   ''' Subfunctions '''
   from prettyNEAT.neat_src._variation import evolvePop, recombine
@@ -90,7 +93,7 @@ class NeatAlgo(NEAlgorithm): #need ask,tell, best params, state stuff is optiona
     return (weightnodes, weights_pad, activations_pad)
     #return self.pop       # Send child population for evaluation
 
-  def tell(self,reward):
+  def tell(self, fitness):
     """Assigns fitness to current population
 
     Args:
@@ -99,10 +102,10 @@ class NeatAlgo(NEAlgorithm): #need ask,tell, best params, state stuff is optiona
 
     """
     for i in range(len(self.pop)):
-      self.pop[i].fitness = reward[i]
+      self.pop[i].fitness = fitness[i]
       self.pop[i].nConn   = self.pop[i].nConn
 
-    self.best_idx = jnp.argmax(reward) #best idx for weights and activation
+    self.best_idx = jnp.argmax(fitness) #best idx for weights and activation
     self.best_weights = self.pop[self.best_idx].wMat #set best
     self.best_activations = self.pop[self.best_idx].aVec
     # for i in range(np.shape(reward)[0]):

--- a/neat_hyperparams.json
+++ b/neat_hyperparams.json
@@ -1,7 +1,7 @@
 {
     "task":"slimevolley",
-    "maxGen": 8,
-    "alg_nReps": 2,
+    "maxGen": 100,
+    "alg_nReps": 5,
     "alg_speciate": "neat",
     "alg_probMoo": 0.0,
     "alg_act": 5,

--- a/prettyNEAT/neat_src/ind.py
+++ b/prettyNEAT/neat_src/ind.py
@@ -5,6 +5,7 @@ import sys
 #sys.path.append('/content/drive/MyDrive/evojax')
 #from .ann import getLayer, getNodeOrder
 from myneat.ann import * #absolute import, run from parent
+from evojax.util import create_logger
 
 import jax.numpy as jnp
 import jax
@@ -45,6 +46,7 @@ class Ind(): #need to initialize in jax
       birth   - (int)      - generation born
       species - (int)      - ID of species
     """
+    self._logger = create_logger(name="Individual")
     self.node = jnp.array(node)
     self.conn = jnp.array(conn)
     self.nInput = jnp.sum(node[1, :] == 1)
@@ -79,7 +81,21 @@ class Ind(): #need to initialize in jax
       self.nConn = jnp.sum(wVec!=0)
       return True
     else:
-      return False
+      self._logger.warning("Cycle detected in network topology, creating minimal network")
+      # Create minimal feedforward network with direct input->output connections
+      n_nodes = self.node.shape[1]
+      self.wMat = jnp.zeros((n_nodes, n_nodes))
+      n_inputs = jnp.sum(self.node[1, :] == 1) + jnp.sum(self.node[1, :] == 4)  # inputs + bias
+      n_outputs = jnp.sum(self.node[1, :] == 2)
+      output_start = n_inputs
+      for i in range(n_inputs):
+        for j in range(n_outputs):
+          self.wMat = self.wMat.at[i, output_start + j].set(0.1 * (jax.random.uniform(jax.random.PRNGKey(i*j)) - 0.5))
+      
+      self.aVec = self.node[2, :]
+      self.wVec = self.wMat.flatten()
+      self.nConn = jnp.sum(self.wVec != 0)
+      return True
 
   def createChild(self, p, innov, gen=0, mate=None, key=None):
     """Create new individual with this individual as a parent


### PR DESCRIPTION
# Fix comprehensive NEAT learning issues preventing slimevolleyball training

## Summary

This PR addresses 8 critical bugs that were preventing the NEAT (NeuroEvolution of Augmenting Topologies) algorithm from learning in the slimevolleyball environment. The training was running without errors but showing no learning progress after many epochs due to structural issues in the implementation.

**Key fixes:**
- **Critical express() method failure handling** - Fixed silent failures in `Individual.express()` that created individuals with empty weight matrices when network topology had cycles
- **Dynamic population size tracking** - Replaced fixed population size with proper dynamic tracking in NEAT algorithm  
- **Neural network forward pass** - Removed hardcoded values that broke with evolving network topologies
- **Interface mismatches** - Fixed parameter name mismatches between trainer and NEAT algorithm (`reward` vs `fitness`)
- **Hyperparameter increases** - Set meaningful training durations (maxGen: 8→100, max-iter: 20→200)
- **Various smaller fixes** - Network size calculations, activation function robustness, logging, package imports

**Testing results:** Training now runs smoothly with consistent population tracking (64 individuals maintained), proper fitness evaluation (-33 to -40 range during training), and no crashes over 20 iterations.

## Review & Testing Checklist for Human

- [ ] **Run longer training sessions (100+ iterations)** to verify sustained learning progress and population dynamics work correctly across extended evolution
- [ ] **Review the fallback network creation logic** in `prettyNEAT/neat_src/ind.py` lines 84-98 - this is a significant design decision for handling cyclic topologies that may need domain expert validation
- [ ] **Test with different hyperparameters and population sizes** to ensure the dynamic population tracking works correctly in various scenarios
- [ ] **Verify fitness evaluation semantics** - confirm that the fitness scores (-33 to -40 range) are reasonable for slimevolleyball and that higher scores indicate better performance
- [ ] **Check for any remaining import/compilation errors** - there are still some diagnostic warnings in myneat/neat.py that may need attention

**Recommended test plan:** Run `PYTHONPATH=/home/ubuntu/evojax:$PYTHONPATH python examples/train_slimevolley.py --max-iter=100 --pop-size=64` and monitor for consistent population tracking, improving fitness scores, and no crashes.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    TrainScript["examples/train_slimevolley.py"]:::minor-edit
    Trainer["evojax/trainer.py"]:::major-edit
    SimMgr["evojax/sim_mgr.py"]:::minor-edit
    NeatAlgo["myneat/neat.py"]:::major-edit
    NeatANN["myneat/ann.py"]:::major-edit
    Individual["prettyNEAT/neat_src/ind.py"]:::major-edit
    Hyperparams["neat_hyperparams.json"]:::minor-edit
    InitFile["myneat/__init__.py"]:::minor-edit
    
    TrainScript -->|"calls trainer"| Trainer
    Trainer -->|"tell(fitness=scores)"| NeatAlgo
    Trainer -->|"eval_params"| SimMgr
    NeatAlgo -->|"creates population"| Individual
    Individual -->|"express() -> wMat, aVec"| NeatANN
    NeatANN -->|"act() forward pass"| SimMgr
    TrainScript -->|"loads config"| Hyperparams
    TrainScript -->|"imports from"| InitFile
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The most critical fix was the `Individual.express()` method failure handling - this was causing silent failures that created individuals with empty networks that could never learn
- Population size tracking was completely broken (fixed value instead of dynamic), preventing proper evolutionary dynamics
- The neural network forward pass had hardcoded assumptions that broke as networks evolved beyond the initial topology
- All fixes have been tested with successful 20-iteration training runs showing consistent population tracking and proper fitness evaluation

**Link to Devin run:** https://app.devin.ai/sessions/876c65bfcfea436da3453d0b366f0fa1  
**Requested by:** Roy (@ryuan19)